### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,10 +13,10 @@ LTC1392	KEYWORD1
 #######################################
 
 get_temperature	KEYWORD2
-get_supply_voltage KEYWORD2
-get_differential_voltage KEYWORD2
-set_shunt KEYWORD2
-get_current KEYWORD2
+get_supply_voltage	KEYWORD2
+get_differential_voltage	KEYWORD2
+set_shunt	KEYWORD2
+get_current	KEYWORD2
 #######################################
 # Instances (KEYWORD2)
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords